### PR TITLE
Allow ruby versions 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
 
-ruby "~> 2.4.2"
+ruby "~> 2.4"
 
 gem 'sinatra'


### PR DESCRIPTION
The actual code `ruby "~> 2.4.2"` allow version from 2.4.2 and less than 2.5.
Stable versions are now 2.4.4 and 2.5.1.
Using the code `ruby "~> 2.4"` is allowing to use all versions 2.x including as well version 2.5.1 but less than version 3.
This solve the problem that when a user try the code locally and he has installed the stable version 2.5.1 get the error:

> Your Ruby version is 2.5.1, but your Gemfile specified ~> 2.4.2
